### PR TITLE
chore(_config.yml): adding correct source to jekyll config

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -1,1 +1,2 @@
+source: docs
 theme: jekyll-theme-cayman


### PR DESCRIPTION
This pull request includes a small change to the `_config.yaml` file. The change sets the `source` to `docs` for the Jekyll site configuration.

* [`_config.yaml`](diffhunk://#diff-2afc28385118ff2b7ecb648754abc1a87dce89acf86a799b1f97b48d41dc5aa5R1): Added `source: docs` to specify the source directory for the Jekyll site.